### PR TITLE
Add query `version` to GraphQL schema

### DIFF
--- a/src/nextline_schedule/__init__.py
+++ b/src/nextline_schedule/__init__.py
@@ -1,4 +1,5 @@
-__all__ = ['Plugin']
+__all__ = ['__version__', 'Plugin']
 
 
+from .__about__ import __version__
 from .plugin import Plugin

--- a/src/nextline_schedule/graphql/__init__.py
+++ b/src/nextline_schedule/graphql/__init__.py
@@ -10,6 +10,7 @@ MUTATE_AUTO_MODE_TURN_OFF = (sub / 'AutoModeTurnOff.gql').read_text()
 sub = pwd / 'queries'
 QUERY_AUTO_MODE = (sub / 'AutoMode.gql').read_text()
 QUERY_SCHEDULER = (sub / 'Scheduler.gql').read_text()
+QUERY_VERSION = (sub / 'Version.gql').read_text()
 
 sub = pwd / 'subscriptions'
 SUBSCRIBE_AUTO_MODE_STATE = (sub / 'ScheduleAutoModeState.gql').read_text()

--- a/src/nextline_schedule/graphql/queries/Version.gql
+++ b/src/nextline_schedule/graphql/queries/Version.gql
@@ -1,0 +1,5 @@
+query Version {
+  schedule {
+    version
+  }
+}

--- a/src/nextline_schedule/plugin.py
+++ b/src/nextline_schedule/plugin.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping, MutableMapping
+from logging import getLogger
 from pathlib import Path
 from typing import Optional
 
@@ -6,6 +7,7 @@ from apluggy import asynccontextmanager
 from dynaconf import Dynaconf, Validator
 from nextlinegraphql.hook import spec
 
+from .__about__ import __version__
 from .auto import build_auto_mode_state_machine
 from .scheduler import DummyRequestStatement, RequestStatement
 from .schema import Mutation, Query, Subscription
@@ -39,6 +41,8 @@ class Plugin:
 
     @spec.hookimpl
     def configure(self, settings: Dynaconf):
+        logger = getLogger(__name__)
+        logger.info(f'{__package__} version: {__version__}')
         api_rul = settings.schedule.api
         length_minutes = settings.schedule.length_minutes
         policy = settings.schedule.policy

--- a/src/nextline_schedule/schema/query.py
+++ b/src/nextline_schedule/schema/query.py
@@ -1,6 +1,8 @@
 import strawberry
 from strawberry.types import Info
 
+import nextline_schedule
+
 
 def query_auto_mode_state(info: Info) -> str:
     auto_mode = info.context["auto_mode"]
@@ -36,6 +38,8 @@ class QueryScheduler:
 
 @strawberry.type
 class QuerySchedule:
+    version: str = nextline_schedule.__version__
+
     @strawberry.field
     def auto_mode(self, info: Info) -> QueryAutoMode:
         return QueryAutoMode()

--- a/tests/schema/queries/test_version.py
+++ b/tests/schema/queries/test_version.py
@@ -1,0 +1,11 @@
+import strawberry
+
+import nextline_schedule
+from nextline_schedule.graphql import QUERY_VERSION
+from nextline_schedule.schema import Query
+
+
+async def test_version():
+    schema = strawberry.Schema(query=Query)
+    resp = await schema.execute(QUERY_VERSION)
+    assert resp.data['schedule']['version'] == nextline_schedule.__version__

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,6 @@
+import nextline_schedule
+
+
+def test_version():
+    '''Confirm that the version string is attached to the module'''
+    nextline_schedule.__version__


### PR DESCRIPTION
This pull request adds a new version query to the GraphQL schema, allowing users to retrieve the version of the package.