### PR TITLE
Require `pytest-httpx>=0.21.3`

### DIFF
--- a/ci/minimum/requirements.txt
+++ b/ci/minimum/requirements.txt
@@ -11,5 +11,5 @@ black==23.10.0
 pytest-asyncio==0.18.0
 pytest-cov==3.0.0
 pytest==7.0.0
-pytest-httpx==0.21.0
+pytest-httpx==0.21.3
 deepdiff==7.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ tests = [
   "pytest-cov>=3.0",
   "pytest-timeout>=2.1",
   "pytest>=7.0",
-  "pytest-httpx>=0.21",
+  "pytest-httpx>=0.21.3",
   "deepdiff>=7.0",
 ]
 


### PR DESCRIPTION
> DEPRECATION: pytest-httpx 0.21.0 has a non-standard dependency specifier pytest<8.*,>=6.*. pip 24.1 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of pytest-httpx or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063
